### PR TITLE
fixed order of nucleotides when featurizing

### DIFF
--- a/forecast_be.py
+++ b/forecast_be.py
@@ -80,7 +80,7 @@ def find_microhomology_about_cutsite(seq, pam=20, window=20):
     max_dist_between_mh = mh_mat.shape[0]-x + y#cutsite + y - x
     return max_mh_len, max_dist_between_mh
 
-all_nucs = ['A', 'C', 'T', 'G']
+all_nucs = ['G', 'A', 'C', 'T']
 all_dinucs = [f'{a}{b}' for a in all_nucs for b in all_nucs]
 def nucleotide_features(seq):
     feature_labels = []

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="forecast_be", 
-    version="0.1",
+    version="0.2",
     author="Ananth Pallaseni",
     author_email="ap32@sanger.ac.uk",
     description="Tools to predict base editor efficacy",


### PR DESCRIPTION
A bug was reported where the order of the nucleotides in the featurization function was different to what the model was expecting. This change fixes the order so that it is line with the models. 